### PR TITLE
buffer: call madvise correctly

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -272,7 +272,7 @@ func (b *Buffer) updateFirst(fsize uint64) {
 	var (
 		start    = b.last % b.capacity
 		end      = (start + fsize) % b.capacity
-		wrapping = end < start
+		wrapping = end <= start
 	)
 
 	if start == end {
@@ -448,7 +448,7 @@ func (b *Buffer) DontNeed(c Cursor) error {
 	var (
 		start    = b.first % b.capacity
 		end      = c.offset % b.capacity
-		wrapping = end < start
+		wrapping = end <= start
 	)
 
 	if s := start % pageSize; s != 0 {
@@ -472,8 +472,9 @@ func (b *Buffer) DontNeed(c Cursor) error {
 
 func (b *Buffer) dontNeed(i, j uint64) error {
 	// Since i is rounded up to the nearest multiple of
-	// pageSize before the call, i > j is not an error.
-	if i > j {
+	// pageSize before the call, i ≥ j is not an error.
+	// i == j can happen when i = j = 0.
+	if i >= j {
 		return nil
 	}
 	return syscall.Madvise(b.data[i:j], syscall.MADV_DONTNEED)

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -366,6 +366,46 @@ func TestOffByOneWrapping(t *testing.T) {
 	}
 }
 
+func TestAdviseOne(t *testing.T) {
+	n := os.Getpagesize()
+	b, err := New(n+total, bufFile)
+	if err != nil {
+		t.Fatalf("Failed to create buffer: %v", err)
+	}
+	defer b.Close()
+
+	data := make([]byte, n)
+	mustInsert(t, b.Insert(data))
+	_, c, err := b.ReadFirst(data)
+	if err != nil {
+		t.Fatalf("b.ReadFirst err = %v; want nil", err)
+	}
+	if err = b.DontNeed(c); err != nil {
+		t.Errorf("b.DontNeed = %v, want nil", err)
+	}
+}
+
+func TestAdviseTwo(t *testing.T) {
+	p := os.Getpagesize()
+	b, err := New(2*p, bufFile)
+	if err != nil {
+		t.Fatalf("Failed to create buffer: %v", err)
+	}
+	defer b.Close()
+
+	mustInsert(t, b.Insert(make([]byte, p-total)))
+	data := make([]byte, 2*p-total)
+	mustInsert(t, b.Insert(data))
+
+	_, c, err := b.ReadFirst(data)
+	if err != nil {
+		t.Fatalf("b.ReadFirst err = %v; want nil", err)
+	}
+	if err = b.DontNeed(c); err != nil {
+		t.Errorf("b.DontNeed = %v, want nil", err)
+	}
+}
+
 func mustInsert(t *testing.T, err error) {
 	if err != nil {
 		t.Fatalf("Insert failed: %v", err)


### PR DESCRIPTION
In the scenarios where the whole buffer region should be madvised
madvise could be called incorrectly.
