### PR TITLE
Bug fix: Unable to read when cursor before first record 

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -380,7 +380,7 @@ func (b *Buffer) Read(data []byte, c Cursor) (n int, next Cursor, err error) {
 	}
 
 	f := b.frame(offset)
-	if f.size() == 0 || f.seq() != seq {
+	if f.size() == 0 || f.seq() != seq || offset < b.first {
 		return b.readFirst(data)
 	}
 


### PR DESCRIPTION
unable to read from buffer when offset is less than offset of the first record