### PR TITLE
Bug cursor before first record

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -380,7 +380,7 @@ func (b *Buffer) Read(data []byte, c Cursor) (n int, next Cursor, err error) {
 	}
 
 	f := b.frame(offset)
-	if f.size() == 0 || f.seq() != seq {
+	if f.size() == 0 || f.seq() != seq || offset < b.first {
 		return b.readFirst(data)
 	}
 

--- a/buffer.go
+++ b/buffer.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/ashishgandhi/buffer/binary"
+	"log"
 )
 
 // buffer file format related sizes
@@ -83,7 +84,7 @@ type Buffer struct {
 
 	// These are start offsets for first and
 	// last records maintained by the buffer.
-	// They are abosulte and not wrapped.
+	// They are absolute and not wrapped.
 	first uint64
 	last  uint64
 
@@ -384,7 +385,13 @@ func (b *Buffer) Read(data []byte, c Cursor) (n int, next Cursor, err error) {
 		return b.readFirst(data)
 	}
 
-	return b.readOffset(data, offset)
+	n1, c1, err := b.readOffset(data, offset)
+	if c1.seq == 0 {
+		log.Printf("f.size()=%d, f.seq()=%d, n1=%d, c1.seq=%d, c1.offset=%d, err=%v, offset=%d, seq=%v, b.filename", f.size(), f.seq(), n1, c1.seq, c1.offset, err, offset, seq, b.filename)
+		b.Unmap()
+		panic("Encountered zero sequence number.")
+	}
+	return n1, c1, err
 }
 
 // ReadFirst reads the first (oldest) record in b. It's return values are analogous


### PR DESCRIPTION
if the courser points on record before the first record - read the first record